### PR TITLE
Eksponerer dependency transitivt og publiserer kildekode-artifakt

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ buildscript {
 }
 
 dependencies {
-    implementation("net.pwall.json:json-kotlin-schema:0.56")
+    api("net.pwall.json:json-kotlin-schema:0.56")
 }
 
 plugins {

--- a/src/main/kotlin/no/domstol/esas/kontrakter/validering/JSONSchemaValidator.kt
+++ b/src/main/kotlin/no/domstol/esas/kontrakter/validering/JSONSchemaValidator.kt
@@ -1,3 +1,5 @@
+package no.domstol.esas.kontrakter.validering
+
 import net.pwall.json.schema.JSONSchema
 import net.pwall.json.schema.JSONSchemaException
 import java.io.InputStream


### PR DESCRIPTION
Får en feil i konsumenten av denne pakken nå, fordi koden
bruker et bibliotek ("io.jstuff:json-validation:4.0") som ikke blir
med. Denne endringen skal løse det.

Publiserer også kildekode for å lettere navigere fra hovedprosjekt under feilsøking.