### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/domstolene/esas-kontrakt/security/code-scanning/3](https://github.com/domstolene/esas-kontrakt/security/code-scanning/3)

To fix the problem, you should declare a `permissions` block at either the root of the workflow (applies to all jobs), or at the job level (within the `build` job). Since this workflow is a simple build CI and does not appear to need increased permissions (such as to create releases or write to PRs/issues), the minimal permission set is `contents: read`.  
The best-practice (and simplest) fix is to add the following block near the top of the workflow, after the `name` line and before `on`:

```yaml
permissions:
  contents: read
```

**Where to change:**  
- File: `.github/workflows/CI.yml`
- Insert after line 1 (`name: CI`) and before line 3 (`on:`).

**What is needed:**  
- No new methods, imports, or dependencies.  
- The only change is to add the YAML `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
