### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -15,6 +15,8 @@ on:
 jobs:
   configure:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       version: ${{steps.version.outputs.version}}
       major_version: ${{steps.version.outputs.major_version}}


### PR DESCRIPTION
Potential fix for [https://github.com/domstolene/esas-kontrakt/security/code-scanning/2](https://github.com/domstolene/esas-kontrakt/security/code-scanning/2)

To fix the identified issue, explicitly set a `permissions` block for the `configure` job in the `.github/workflows/Release.yml` file, or at the workflow root to apply to all jobs. Since the `configure` job only performs Bash scripting and does not interact with GitHub contents or APIs, the least privilege is `contents: read`, which is the minimum possible (and no `write` permissions are needed).  

The best fix is to:  
1. Add a `permissions` block to the `configure` job.  
2. Set it as `contents: read` to reflect the least privilege required.  
3. Insert this block just above or below the `runs-on` property of the `configure` job (conventionally above or right below `runs-on`).

No new methods or imports are needed; this is a matter of adding YAML configuration for GitHub Actions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
